### PR TITLE
trackBy function for ngFor loop

### DIFF
--- a/projects/select-autocomplete/src/lib/select-autocomplete.component.ts
+++ b/projects/select-autocomplete/src/lib/select-autocomplete.component.ts
@@ -49,7 +49,7 @@ import { FormControl } from "@angular/forms";
           {{ onDisplayString() }}
         </mat-select-trigger>
         <mat-option
-          *ngFor="let option of options"
+          *ngFor="let option of options; trackBy: trackByFn"
           [disabled]="option.disabled"
           [value]="option[value]"
           [style.display]="hideOption(option) ? 'none' : 'flex'"
@@ -238,5 +238,9 @@ export class SelectAutocompleteComponent implements OnChanges, DoCheck {
     }
     this.selectedValue = val.value;
     this.selectionChange.emit(this.selectedValue);
+  }
+
+  public trackByFn(index, item) {
+    return item.value;
   }
 }


### PR DESCRIPTION
In code where the options input can change, adding a trackBy function prevents the select list with options to reload (and thus flicker on screen). 