### PR TITLE
Fix so that filtered options values respects the component's [value] …

### DIFF
--- a/projects/select-autocomplete/src/lib/select-autocomplete.component.ts
+++ b/projects/select-autocomplete/src/lib/select-autocomplete.component.ts
@@ -183,7 +183,7 @@ export class SelectAutocompleteComponent implements OnChanges, DoCheck {
   getFilteredOptionsValues() {
     const filteredValues = [];
     this.filteredOptions.forEach(option => {
-      filteredValues.push(option.value);
+      filteredValues.push(option[this.value]);
     });
     return filteredValues;
   }


### PR DESCRIPTION
Currently source hard-codes the .value property in getFilteredOptionsValues() but should reference this.value from the component's input [value]